### PR TITLE
Attempt to help you with Docusaurus v2 Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,15 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>rarkins/.github:renovate-config"
-  ],
+  "extends": ["config:base"],
   "dependencyDashboard": true,
   "lockFileMaintenance": {
     "enabled": true
   },
-  "packageRules": [{
-    "updateTypes" :["major"],
-    "dependencyDashboardApproval": true
-  }]
+  "stabilityDays": 3,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "updateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>rarkins/.github:renovate-config"
-  ]
+  ],
+  "dependencyDashboard": true,
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "packageRules": [{
+    "updateTypes" :["major"],
+    "dependencyDashboardApproval": true
+  }]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,16 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
   "dependencyDashboard": true,
   "lockFileMaintenance": {
+    "description": "Refresh lock file weekly on mondays",
     "enabled": true
   },
   "stabilityDays": 3,
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "description": "Require approval before proposing any major updates",
       "updateTypes": ["major"],
       "dependencyDashboardApproval": true
     }


### PR DESCRIPTION
Hi @rarkins 👋 

I thought I would try to get us going with the Renovate config that we promised to the Docusaurus maintainer.
I've made a checklist style comment, so that we can check if we're giving them what they want. 😄 
Feel free to edit my post to your liking. 👍 

If you find this "help" annoying, please tell me, and I will close the PR, and let you deal with it in your own time. 😉

## Help needed with config:

### ignore Docusaurus v1 for general updates

- [ ] Ignore Docusaurus v1 packages

### Complicated versioning requirements:

- [ ] Keep SemVer ranges in `package.json`, do not pin end-users to a specific version, I don't know whether `rangeStrategy` should use `bump`, `replace`, or `update-lockfile` or just stick to `auto`...
- [ ] Group dev-deps into a dev grouped update (this seems error prone to me, I'm not sure this is helpful for them)

## Raise security updates immediately

- [ ] Raise security PRs immediately
- [ ] Raise security updates for Docusaurus v1 even though it's ignored for all other updates

### Conform to their conventional commit scheme:

They already use angular style commits, so maybe Renovate will do the right thing.

- [ ] dev-updates and prod-updates to Docusaurus v2 use the `chore(v2): upgrade ESLint ...` kind of scheme

### Potential problem, what do to with Group Preset for Docusaurus monorepo?

Because the project is itself the main source of Docusaurus updates, what do we do with the `group:docusaurusMonorepo` Group Preset that Renovate uses by default?

- [ ] Ensure Docusaurus Group Preset is OK

## What I managed to cobble together as a starter config

- [x] Enable dependency dashboard explicitly (this is so it's clear from the config that it's turned on)
- [x] MAJOR versions go through the dashboard
- [x] Use lock file maintenance on `yarn.lock` (once a week on Mondays by Renovate default)
- [x] No auto-merge of any kind
- [x] Don't assign the PRs to anybody
- [x] Add `dependencies` label to pull requests (they're using this label already on their repo)
- [x] Use `"stabilityDays": 3` to hold back npm updates that might get delisted from the registry